### PR TITLE
修复老版本ping不支持"-4" "-6"参数的问题

### DIFF
--- a/ss-tproxy
+++ b/ss-tproxy
@@ -4,6 +4,9 @@ trap "exit 1" HUP INT QUIT TERM PIPE
 
 PATH=$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
+PING='ping'
+PING6='ping6'   # use ping6 by default
+
 ss_tproxy_config='/etc/ss-tproxy/ss-tproxy.conf'
 
 readonly IPV4_RESERVED_IPADDRS=(
@@ -76,6 +79,18 @@ file_is_exists() {
 
 command_is_exists() {
     command -v "$1" &>/dev/null
+}
+
+ping_cmd_fix() {
+    command_is_exists "$PING6"
+    if [ $? -eq 0 ]; then
+        local link_to=$(readlink $(command -v $PING6))
+        if [ -z "$link_to" ]; then
+            return
+        fi
+    fi
+    PING='ping -4'
+    PING6='ping -6'
 }
 
 process_is_running() {
@@ -193,7 +208,8 @@ resolve_hostname_by_getent() {
 
 resolve_hostname_by_ping() {
     local addr_family="$1" hostname="$2"
-    ping "$addr_family" -nq -c1 -t1 -W1 "$hostname" | head -n1 | sed -r 's/\(|\)/|/g' | awk -F'|' '{print $2}'
+    [ "$addr_family" = '-4' ] && local ping_cmd="$PING" || local ping_cmd="$PING6"
+    $ping_cmd -nq -c1 -t1 -W1 "$hostname" | head -n1 | sed -r 's/\(|\)/|/g' | awk -F'|' '{print $2}'
 }
 
 resolve_hostname4() {
@@ -216,12 +232,12 @@ resolve_hostname6() {
 
 waiting_network() {
     if is_ipv4_address "$1"; then
-        until ping -4 -nq -c1 -W1 "$1" >/dev/null; do
+        until $PING -nq -c1 -W1 "$1" >/dev/null; do
             echo "waiting for network available..."
             sleep 1
         done
     elif is_ipv6_address "$1"; then
-        until ping -6 -nq -c1 -W1 "$1" >/dev/null; do
+        until $PING6 -nq -c1 -W1 "$1" >/dev/null; do
             echo "waiting for network available..."
             sleep 1
         done
@@ -1133,6 +1149,7 @@ main() {
         return 1
     fi
 
+    ping_cmd_fix
     load_config
     check_config
 


### PR DESCRIPTION
这个PR应该可以修复 #98 

`Ubuntu 16.04`等发行版使用老版本的`ping`命令，其`ping6`作为单独的二进制释放，不支持`-4`、`-6`参数；`Ubuntu 18.04`上`ping6`为链接到`ping`，支持`-4`、`-6`参数；`archlinux`上没有`ping6`。

新版本`ping`去解析域名时会优先使用IPv6，老版本`ping`仅支持IPv4，`ping6`才能支持IPv6。

所以根据`ping6`是否存在以及`ping6`是否为软链接，来修改`ping`命令：`ping6`不存在以及`ping6`为软链接时，使用`ping -4`和`ping -6`，否则使用`ping`和`ping6`