### PR TITLE
prevent systemd-networkd from deleting fwmark rule

### DIFF
--- a/ss-tproxy
+++ b/ss-tproxy
@@ -829,7 +829,7 @@ start_iptables_pre_rules() {
         local iproute2_family
         is_ipv4_ipts $1 && iproute2_family="-4" || iproute2_family="-6"
         ip $iproute2_family route add local default dev $ipts_if_lo table $ipts_rt_tab
-        if ip rule help 2>&1 | grep -q protocol; then
+        if ip rule help 2>&1 | grep -Fwq protocol; then
             ip $iproute2_family rule add fwmark $ipts_rt_mark table $ipts_rt_tab protocol kernel
         else
             ip $iproute2_family rule add fwmark $ipts_rt_mark table $ipts_rt_tab

--- a/ss-tproxy
+++ b/ss-tproxy
@@ -829,12 +829,11 @@ start_iptables_pre_rules() {
         local iproute2_family
         is_ipv4_ipts $1 && iproute2_family="-4" || iproute2_family="-6"
         ip $iproute2_family route add local default dev $ipts_if_lo table $ipts_rt_tab
-        if ip rule help 2>&1 | grep -q protocol ; then
-            ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab protocol kernel
+        if ip rule help 2>&1 | grep -q protocol; then
+            ip $iproute2_family rule add fwmark $ipts_rt_mark table $ipts_rt_tab protocol kernel
         else
-            ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab
+            ip $iproute2_family rule add fwmark $ipts_rt_mark table $ipts_rt_tab
         fi
-        
     fi
 }
 

--- a/ss-tproxy
+++ b/ss-tproxy
@@ -829,7 +829,12 @@ start_iptables_pre_rules() {
         local iproute2_family
         is_ipv4_ipts $1 && iproute2_family="-4" || iproute2_family="-6"
         ip $iproute2_family route add local default dev $ipts_if_lo table $ipts_rt_tab
-        ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab protocol kernel
+        if ip rule help 2>&1 | grep -q protocol ; then
+            ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab protocol kernel
+        else
+            ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab
+        fi
+        
     fi
 }
 

--- a/ss-tproxy
+++ b/ss-tproxy
@@ -829,7 +829,7 @@ start_iptables_pre_rules() {
         local iproute2_family
         is_ipv4_ipts $1 && iproute2_family="-4" || iproute2_family="-6"
         ip $iproute2_family route add local default dev $ipts_if_lo table $ipts_rt_tab
-        ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab
+        ip $iproute2_family rule  add fwmark $ipts_rt_mark          table $ipts_rt_tab protocol kernel
     fi
 }
 


### PR DESCRIPTION
a recent systemd update (247.4 or maybe earlier version) may delete foreign fwmark rules when systemd-networkd.service got restarted or RJ45 cable loses signal. this patch could stop systemd-networkd from doing so.

最近版本的systemd更新, 带来一个bug, 如果是用的systemd-networkd配置的网络, 在systemd-networkd.service重启的时候或者网口丢失信号的时候, 其他程序创建的fwmark的规则会被删除. 本patch会阻止此事发生.